### PR TITLE
Fix pytorch-lighting version error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-torch>=1.13.0
-torchvision>=0.9.0
-pytorch-lightning>=1.0.6
+torch==1.13.0
+torchvision==0.9.0
+pytorch-lightning==1.0.6
 Pillow
 numpy
 tqdm


### PR DESCRIPTION
Hello, I found an issue with the `requirements.txt` file, inside it's specified `pytorch-lighting>=1.0.6` but in fact if you make `pip install -r requirements.txt` pip will install the pytorch-lighting 2.0.4 that will break the training script.

```
Traceback (most recent call last):
  File "train.py", line 155, in <module>
    main()
  File "train.py", line 151, in main
    train_wasr(args)
  File "train.py", line 135, in train_wasr
    trainer = pl.Trainer(logger=logger,
  File "/home/ubuntu/.local/lib/python3.8/site-packages/pytorch_lightning/utilities/argparse.py", line 70, in insert_env_defaults
    return fn(self, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'gpus'
```

In this version the arguments gpus no longer exist, so I simply lock the version inside requirements.txt by using == instead of >=.